### PR TITLE
Add ShakaAdsTracker to video-shaka-js

### DIFF
--- a/src/ads.js
+++ b/src/ads.js
@@ -1,0 +1,123 @@
+import * as nrvideo from "newrelic-video-core";
+import { version } from "../package.json";
+
+export default class ShakaAdsTracker extends nrvideo.VideoTracker {
+  getTrackerName() {
+    return "shaka-ads";
+  }
+
+  getTrackerVersion() {
+    return version;
+  }
+
+  getDuration() {
+    return this.duration;
+  }
+
+  getSrc() {
+    return this.resource;
+  }
+
+  getPlayhead() {
+    return this.playhead;
+  }
+
+  getTitle() {
+    return this.title;
+  }
+
+  getAdCreativeId() {
+    return this._creativeId;
+  }
+
+  registerListeners() {
+    nrvideo.Log.debugCommonVideoEvents(this.player, [
+      null,
+      "ad-started",
+      "ad-complete",
+      "ad-progress",
+      "ad-impression",
+      "ad-resumed",
+      "ad-paused",
+      "ad-skipped",
+      "ad-clicked",
+    ]);
+
+    const adManager = this.player.getAdManager();
+    adManager.addEventListener("ad-started", this.onStarted.bind(this));
+    adManager.addEventListener("ad-complete", this.onComplete.bind(this));
+    adManager.addEventListener("ad-progress", this.onTime.bind(this));
+    adManager.addEventListener("ad-impression", this.onImpression.bind(this));
+    adManager.addEventListener("ad-resumed", this.onPlay.bind(this));
+    adManager.addEventListener("ad-paused", this.onPause.bind(this));
+    adManager.addEventListener("ad-skipped", this.onSkipped.bind(this));
+    adManager.addEventListener("ad-clicked", this.onClick.bind(this));
+  }
+
+  unregisterListeners() {
+    const adManager = this.player.getAdManager();
+
+    adManager.removeEventListener("ad-started", this.onStarted);
+    adManager.removeEventListener("ad-complete", this.onComplete);
+    adManager.removeEventListener("ad-progress", this.onTime);
+    adManager.removeEventListener("ad-impression", this.onImpression);
+    adManager.removeEventListener("ad-resumed", this.onPlay);
+    adManager.removeEventListener("ad-paused", this.onPause);
+    adManager.removeEventListener("ad-skipped", this.onSkipped);
+    adManager.removeEventListener("ad-clicked", this.onClick);
+  }
+
+  onTime(event) {
+    this.playhead = event.originalEvent.h.currentTime;
+    this.duration = event.originalEvent.h.duration;
+  }
+
+  onStarted(event) {
+    this._creativeId = event.sdkAdObject.h.creativeId;
+    this.resource = event.sdkAdObject.h.clickThroughUrl;
+    this.title = event.sdkAdObject.h.title;
+
+    this.sendRequest();
+    this.sendStart();
+  }
+
+  onImpression(event) {
+    this.resource = event.sdkAdObject.h.clickThroughUrl;
+    this.title = event.sdkAdObject.h.title;
+  }
+
+  onPause(_event) {
+    this.sendPause();
+  }
+
+  onPlay(_event) {
+    this.sendResume();
+  }
+
+  onSkipped(_event) {
+    this.sendEnd({ skipped: true });
+    this.resetValues();
+  }
+
+  onComplete(_event) {
+    this.sendEnd();
+    this.resetValues();
+  }
+
+  onClick(event) {
+    this.sendAdClick({ url: event.tag });
+  }
+
+  onError(event) {
+    this.sendError({ errorMessage: event.message });
+    this.sendEnd();
+  }
+
+  resetValues() {
+    this.playhead = undefined;
+    this.duration = undefined;
+    this.resource = undefined;
+    this.title = undefined;
+    this._creativeId = undefined;
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
-import * as nrvideo from 'newrelic-video-core'
-import Tracker from './tracker'
+import * as nrvideo from "newrelic-video-core";
+import Tracker from "./tracker";
+import AdsTracker from "./ads";
 
-nrvideo.ShakaTracker = Tracker
+nrvideo.ShakaTracker = Tracker;
+nrvideo.ShakaAdsTracker = AdsTracker;
 
-module.exports = nrvideo
+module.exports = nrvideo;


### PR DESCRIPTION
The `ShakaAdsTracker` is used to track ads progress. It's based on the existing one for `jwplayer` but with the correct events for Shaka Player.
