### PR TITLE
Seek events were not dispatched anymore

### DIFF
--- a/src/tracker.js
+++ b/src/tracker.js
@@ -88,7 +88,7 @@ export default class ShakaTracker extends nrvideo.VideoTracker {
     this.tag.addEventListener('play', this.onPlayListener)
     this.tag.addEventListener('playing', this.onPlayingListener)
     this.tag.addEventListener('pause', this.onPauseListener)
-    this.tag.addEventListener('seeking', this.onSeekedListener)
+    this.tag.addEventListener('seeking', this.onSeekingListener)
     this.tag.addEventListener('seeked', this.onSeekedListener)
     this.tag.addEventListener('error', this.onErrorListener)
     this.tag.addEventListener('ended', this.onEndedListener)


### PR DESCRIPTION
# 🕵️‍♂️ Description

In a previous refactor (ref: #4) back in January, we inserted a typo causing seek events to not be dispatched anymore.

The `onSeek` event was taking over the `onSeeking` reference which led to never going into a seek state in NewRelic.

# 🖼️ Results

Now seek events are populated as expected:

![Screenshot 2023-05-12 at 8 21 25 AM](https://github.com/mirego/video-shaka-js/assets/513491/04260da4-a44b-41f9-a7ef-07948b124e08)
