### PR TITLE
Enhancements to Shaka Error Handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "src/index.js",
   "scripts": {
     "test": "jest --coverage",
-    "build": "webpack -p",
+    "build": "webpack --mode production",
     "build:dev": "webpack --mode development",
-    "watch": "webpack -p --progress --color --watch",
-    "watch:dev": "webpack --progress --color --watch",
+    "watch": "webpack --mode production --progress --color --watch",
+    "watch:dev": "webpack --mode development --progress --color --watch",
     "prezip": "npm run build",
     "zip": "zip -P newrelic -x '*.DS_Store' -r shaka.zip dist samples README.md CHANGELOG.md EULA.md",
     "clean": "rm -rf dist *.zip",

--- a/src/__test__/tracker.test.js
+++ b/src/__test__/tracker.test.js
@@ -309,7 +309,7 @@ describe("registerListeners", () => {
       "seeking",
       expect.any(Function)
     );
-    expect(shakaTracker.tag.addEventListener).toHaveBeenCalledWith(
+    expect(shakaTracker.player.addEventListener).toHaveBeenCalledWith(
       "error",
       expect.any(Function)
     );
@@ -363,7 +363,7 @@ describe("unregisterListeners", () => {
       "seeking",
       expect.any(Function)
     );
-    expect(shakaTracker.tag.addEventListener).toHaveBeenCalledWith(
+    expect(shakaTracker.player.addEventListener).toHaveBeenCalledWith(
       "error",
       expect.any(Function)
     );

--- a/src/__test__/utils/mapper.test.js
+++ b/src/__test__/utils/mapper.test.js
@@ -1,0 +1,85 @@
+import ShakaToNewRelicMapper from '../../utils/mapper';
+
+describe('ShakaToNewRelicMapper', () => {
+  describe('mapErrorAttributes', () => {
+    it('should return the mapped error attributes', () => {
+      const attributes = {
+        code: 1001,
+        platformCode: 'PLATFORM_ERROR',
+        message: 'An error occurred',
+        stack: 'Error stack trace',
+        severity: 2,
+        extraAttribute: 'extraValue'
+      };
+
+      const result = ShakaToNewRelicMapper.mapErrorAttributes(attributes);
+
+      expect(result).toEqual({
+        errorCode: 1001,
+        errorPlatformCode: 'PLATFORM_ERROR',
+        errorMessage: 'An error occurred',
+        errorStackTrace: 'Error stack trace',
+        errorSeverity: 'CRITICAL',
+        extraAttribute: 'extraValue'
+      });
+    });
+
+    it('should truncate the stack trace if it exceeds the maximum length', () => {
+      const longStackTrace = 'a'.repeat(5000);
+      const attributes = {
+        stack: longStackTrace
+      };
+
+      const result = ShakaToNewRelicMapper.mapErrorAttributes(attributes);
+
+      expect(result.errorStackTrace.length).toBe(4096);
+    });
+
+    it('should return the original attributes if input is not an object', () => {
+      const attributes = 'not an object';
+
+      const result = ShakaToNewRelicMapper.mapErrorAttributes(attributes);
+
+      expect(result).toBe(attributes);
+    });
+
+    it('should handle undefined stack trace gracefully', () => {
+      const attributes = {
+        code: 1001,
+        platformCode: 'PLATFORM_ERROR',
+        message: 'An error occurred',
+        severity: 2
+      };
+
+      const result = ShakaToNewRelicMapper.mapErrorAttributes(attributes);
+
+      expect(result).toEqual({
+        errorCode: 1001,
+        errorPlatformCode: 'PLATFORM_ERROR',
+        errorMessage: 'An error occurred',
+        errorStackTrace: undefined,
+        errorSeverity: 'CRITICAL'
+      });
+    });
+
+    it('should map severity correctly', () => {
+      const attributes = {
+        severity: 1
+      };
+
+      const result = ShakaToNewRelicMapper.mapErrorAttributes(attributes);
+
+      expect(result.errorSeverity).toBe('RECOVERABLE');
+    });
+
+    it('should retain unknown severity values', () => {
+      const attributes = {
+        severity: 3
+      };
+
+      const result = ShakaToNewRelicMapper.mapErrorAttributes(attributes);
+
+      expect(result.errorSeverity).toBe(3);
+    });
+  });
+});

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -1,5 +1,6 @@
 import * as nrvideo from "newrelic-video-core";
 import { version } from "../package.json";
+import ShakaToNewRelicMapper from "./utils/mapper";
 
 export default class ShakaTracker extends nrvideo.VideoTracker {
   setPlayer(player, tag) {
@@ -103,9 +104,9 @@ export default class ShakaTracker extends nrvideo.VideoTracker {
     this.tag.addEventListener("pause", this.onPauseListener);
     this.tag.addEventListener("seeking", this.onSeekingListener);
     this.tag.addEventListener("seeked", this.onSeekedListener);
-    this.tag.addEventListener("error", this.onErrorListener);
     this.tag.addEventListener("ended", this.onEndedListener);
 
+    this.player.addEventListener("error", this.onErrorListener);
     this.player.addEventListener("buffering", this.onBufferingListener);
     this.player.addEventListener("adaptation", this.onAdaptationListener);
   }
@@ -119,9 +120,9 @@ export default class ShakaTracker extends nrvideo.VideoTracker {
     this.tag.removeEventListener("pause", this.onPauseListener);
     this.tag.removeEventListener("seeking", this.onSeekingListener);
     this.tag.removeEventListener("seeked", this.onSeekedListener);
-    this.tag.removeEventListener("error", this.onErrorListener);
     this.tag.removeEventListener("ended", this.onEndedListener);
 
+    this.player.removeEventListener("error", this.onErrorListener);
     this.player.removeEventListener("buffering", this.onBufferingListener);
     this.player.removeEventListener("adaptation", this.onAdaptationListener);
   }
@@ -164,7 +165,7 @@ export default class ShakaTracker extends nrvideo.VideoTracker {
   }
 
   onError(e) {
-    this.sendError(e.detail);
+    this.sendError(ShakaToNewRelicMapper.mapErrorAttributes(e.detail));
   }
 
   onEnded() {

--- a/src/utils/mapper.js
+++ b/src/utils/mapper.js
@@ -1,0 +1,31 @@
+const NR_ERROR_CODE = 'errorCode';
+const NR_ERROR_PLATFORM_CODE = 'errorPlatformCode';
+const NR_ERROR_MESSAGE = 'errorMessage';
+const NR_ERROR_STACK_TRACE = 'errorStackTrace';
+const NR_ERROR_SEVERITY = 'errorSeverity';
+const NR_MAX_NUMBER_OF_CHARACTERS_FOR_STRING_ATTRIBUTE = 4096;
+
+const SHAKA_SEVERITY_MAP = {
+  1: 'RECOVERABLE',
+  2: 'CRITICAL'
+};
+
+export default class ShakaToNewRelicMapper {
+  static mapErrorAttributes(attributes) {
+    if (!attributes || typeof attributes !== 'object') return attributes;
+
+    const { code, platformCode, message, stack, severity, ...remainingAttributes } = attributes;
+
+    const stackTrace = stack && typeof stack === 'string' ? stack.substring(0, NR_MAX_NUMBER_OF_CHARACTERS_FOR_STRING_ATTRIBUTE) : undefined;
+    const errorSeverity = SHAKA_SEVERITY_MAP[severity] || severity;
+
+    return {
+      [NR_ERROR_CODE]: code,
+      [NR_ERROR_PLATFORM_CODE]: platformCode,
+      [NR_ERROR_MESSAGE]: message,
+      [NR_ERROR_STACK_TRACE]: stackTrace,
+      [NR_ERROR_SEVERITY]: errorSeverity,
+      ...remainingAttributes
+    };
+  }
+}


### PR DESCRIPTION
## 📖 Description

This PR introduces a mapper to transform Shaka errors into a more organized format for New Relic.

## 👷 Work Done

-  Attached the error `EventListener` to the player instead of its tag. This change seemed necessary to obtain the detail of the error. It is also the method described in the Shaka documentation: https://shaka-player-demo.appspot.com/docs/api/tutorial-errors.html
- Introduced a mapper to transform Shaka errors into a more organized format for New Relic, aiming to align as closely as possible with their [Data dictionary](https://docs.newrelic.com/attribute-dictionary/?dataSource=Browser+agent).
  - Changed `message` to `errorMessage`
  - Changed `code` to `errorCode`
  - etc.
- Added tests for the features introduced.


## 🗒 Notes

I've also noticed that the `-p` flag used by Webpack for building the library is no longer supported, so I've updated `package.json` to utilize the new `--mode` flag.


