### PR TITLE
Update webpack build to output chrome 53 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "aws-sdk": "^2.920.0",
         "babel-jest": "^29.7.0",
         "babel-loader": "^8.0.0",
+        "core-js": "^3.46.0",
         "jest": "^29.7.0",
         "videojs-ima": "^0.6.0",
         "webpack": "^5.94.0",
@@ -6356,6 +6357,17 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.47.0.tgz",
+      "integrity": "sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.46.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "aws-sdk": "^2.920.0",
     "babel-jest": "^29.7.0",
     "babel-loader": "^8.0.0",
+    "core-js": "^3.46.0",
     "jest": "^29.7.0",
     "videojs-ima": "^0.6.0",
     "webpack": "^5.94.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,5 @@
 var path = require('path');
 var webpack = require('webpack');
-var TerserPlugin = require('terser-webpack-plugin');
 
 var pkg = require('./package.json');
 var license =
@@ -15,11 +14,11 @@ var license =
   pkg.author;
 
 module.exports = [
+  // Modern build (no ES5 transpilation)
   {
-    //umd
     entry: './src/index.js',
     output: {
-      path: path.resolve(__dirname, './dist/umd'),
+      path: path.resolve(__dirname, './dist'),
       filename: 'newrelic-video-shaka.min.js',
       library: 'nrvideo',
       libraryTarget: 'umd',
@@ -47,74 +46,42 @@ module.exports = [
       }),
     ],
   },
-  // commonjs buid
+  // Chrome 53+ build (with polyfills)
   {
     entry: './src/index.js',
     output: {
-      path: path.resolve(__dirname, './dist/cjs'),
-      filename: 'index.js',
+      path: path.resolve(__dirname, './dist'),
+      filename: 'newrelic-video-shaka.es5.min.js',
       library: 'nrvideo',
-      libraryTarget: 'commonjs2', // CommonJS format
+      libraryTarget: 'umd',
+      libraryExport: 'default',
+      globalObject: 'this',
     },
     devtool: 'source-map',
     module: {
       rules: [
         {
-          test: /\.(js|mjs|cjs)$/,
-          exclude: /node_modules/,
-          use: {
-            loader: 'babel-loader',
-            options: {
-              presets: [['@babel/preset-env', { targets: 'defaults' }]],
-            },
-          },
-        },
-      ],
-    },
-    optimization: {
-      minimize: true,
-      minimizer: [new TerserPlugin()],
-    },
-    plugins: [
-      new webpack.BannerPlugin({
-        banner: license,
-        entryOnly: true,
-      }),
-    ],
-  },
-  // ES Module Build
-  {
-    entry: './src/index.js',
-    output: {
-      path: path.resolve(__dirname, './dist/esm'),
-      filename: 'index.js',
-      library: {
-        type: 'module', // ES Module format
-      },
-    },
-    experiments: {
-      outputModule: true, // Enable ES Module output
-    },
-    devtool: 'source-map',
-    module: {
-      rules: [
-        {
-          test: /\.(js|mjs|cjs)$/,
-          exclude: /node_modules/,
+          test: /\.(?:js|mjs|cjs)$/,
+          exclude: /node_modules\/(?!(newrelic-video-core|codem-isoboxer))/,
           use: {
             loader: 'babel-loader',
             options: {
               presets: [
-                ['@babel/preset-env', { targets: 'defaults', modules: false }],
+                [
+                  '@babel/preset-env',
+                  {
+                    targets: {
+                      chrome: '53',
+                    },
+                    useBuiltIns: 'usage',
+                    corejs: 3,
+                  },
+                ],
               ],
             },
           },
         },
       ],
-    },
-    optimization: {
-      minimize: true,
-      minimizer: [new TerserPlugin()],
     },
     plugins: [
       new webpack.BannerPlugin({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,7 +62,6 @@ module.exports = [
       rules: [
         {
           test: /\.(?:js|mjs|cjs)$/,
-          exclude: /node_modules\/(?!(newrelic-video-core|codem-isoboxer))/,
           use: {
             loader: 'babel-loader',
             options: {


### PR DESCRIPTION
We now output both .min and es5.min

41kb vs 98kb

<img width="302" height="160" alt="Screenshot 2025-12-11 at 8 57 46 AM" src="https://github.com/user-attachments/assets/267a960f-a5eb-4398-ade1-59a0913b3d79" />
